### PR TITLE
reordered - two downloads before two saves

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ __pycache__
 Dockerfile
 README.md
 *.ipynb
+deepset

--- a/get_roberta.py
+++ b/get_roberta.py
@@ -1,14 +1,16 @@
 from transformers import AutoTokenizer
 from transformers import AutoModelForQuestionAnswering
 
-def run():
-    model_checkpoint = "deepset/roberta-base-squad2-distilled"
 
-    model = AutoModelForQuestionAnswering.from_pretrained(model_checkpoint)
-    model.save_pretrained(model_checkpoint, from_pt=True)
+def run(checkpoint):
+    """ download model and associated tokenizer from https://huggingface.co/models """
 
-    tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
-    tokenizer.save_pretrained(model_checkpoint, from_pt=True)
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    model = AutoModelForQuestionAnswering.from_pretrained(checkpoint)
+
+    tokenizer.save_pretrained(checkpoint, from_pt=True)
+    model.save_pretrained(checkpoint, from_pt=True)
+
 
 if __name__ == "__main__":
-    run()
+    run(checkpoint="deepset/roberta-base-squad2-distilled")


### PR DESCRIPTION
 
=> ERROR [5/5] RUN python3 get_roberta.py                                                   44.4s
 > [5/5] RUN python3 get_roberta.py:
Downloading (…)lve/main/config.json: 100%|██████████| 729/729 [00:00<00:00, 6.78MB/s]
Downloading pytorch_model.bin: 100%|██████████| 496M/496M [00:38<00:00, 12.9MB/s] 
#0 43.32 Traceback (most recent call last):
#0 43.32   File "/app/get_roberta.py", line 14, in <module>
#0 43.32     run()
#0 43.32   File "/app/get_roberta.py", line 10, in run
#0 43.32     tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
#0 43.32   File "/usr/local/lib/python3.10/site-packages/transformers/models/auto/tokenization_auto.py", line 711, in from_pretrained
#0 43.32     return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
#0 43.32   File "/usr/local/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 1796, in from_pretrained
#0 43.32     raise EnvironmentError(
#0 43.32 OSError: Can't load tokenizer for 'deepset/roberta-base-squad2-distilled'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'deepset/roberta-base-squad2-distilled' is the correct path to a directory containing all relevant files for a RobertaTokenizerFast tokenizer.

The problem was the order of commands in `get_roberta.py`: download model, save model, download tokenizer, save tokenizer. The fix was to re-order: download, download, save, save.

And the reason I hadn't caught the error was that my `.dockerignore` was missing "deepset." Locally, I was mistakenly copying the model directory into the new image, rather than trying to download it. Once I added the local directory "deepset" to the `.dockerignore`, I was able to reproduce the error reported by others.

Rather than rely on local debugging, I will also deploy the image to GCP this time.